### PR TITLE
feature(plugin): allow configuration for skipping good commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ Defaults to `"Greetings."`.
 String to start the response with.
 Defaults to `"Farewell."`.
 
+### `poppins.plugins.prChecklist.good`
+
+String to display on a commit that doesn't fail any validations.
+Defaults to `"Thanks for the PR! Looks good."`.
+If this is set to a falsy value then no comment will be created on a good commit.
+
 
 ### `poppins.plugins.prChecklist.checks`
 

--- a/plugin.js
+++ b/plugin.js
@@ -29,7 +29,9 @@ function respondToPullRequest (data) {
 
   return prChecklist.responseBody(data).
     then(function (body) {
-      return poppins.createComment(number, body);
+      if (body !== "") {
+        return poppins.createComment(number, body);
+      }
     }).
     done(function () {
       poppins.emit('plugin:pr:done');
@@ -38,7 +40,15 @@ function respondToPullRequest (data) {
 
 function responseBody (data) {
   return prChecklist.checklist(data).then(function (list) {
-    return list ? Q.all([prChecklist.greeting, list, prChecklist.closing]) : [prChecklist.good]
+    if (list) {
+      return Q.all([prChecklist.greeting, list, prChecklist.closing]);
+    }
+
+    if (prChecklist.good) {
+      return [prChecklist.good];
+    }
+
+    return [];
   }).
   then(function (paragraphs) {
     return paragraphs.join('\n\n');


### PR DESCRIPTION
If the `plugins.prChecklist.good` is set to a falsy value then no
comment will be added to that pull request.

The `plugins.prChecklist.good` option was previously undocumented. It
has been added to `README.md` as well as a note for the new falsy
option.
